### PR TITLE
[#88] .png 로드한 컴포넌트 테스트시 발생하는 에러 && [#89] axios maker 불필요한 console.error

### DIFF
--- a/frontEnd/package-lock.json
+++ b/frontEnd/package-lock.json
@@ -5457,6 +5457,12 @@
         "har-schema": "^2.0.0"
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5934,6 +5940,15 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.0.0.tgz",
       "integrity": "sha512-aF2Cf/CkEZrI/vsu5WI/I+akFgdbwQHVE9YRZxATrhH4PVIe6a3BIjwjEcW+z+jP/hNh+YvM3lAAn1wJQ6opSg==",
       "dev": true
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
+      }
     },
     "ieee754": {
       "version": "1.2.1",

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest ./frontEnd",
     "start": "webpack serve",
-    "build": "webpack"
+    "build": "webpack",
+    "watchTest": "jest --watchAll"
   },
   "keywords": [],
   "author": "",

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -38,6 +38,7 @@
     "css-loader": "^5.0.0",
     "file-loader": "^6.1.1",
     "html-webpack-plugin": "^4.5.0",
+    "identity-obj-proxy": "^3.0.0",
     "isomorphic-fetch": "^3.0.0",
     "jest": "^26.6.1",
     "msw": "^0.21.3",
@@ -49,6 +50,9 @@
     "webpack-dev-server": "^3.11.0"
   },
   "jest": {
+    "moduleNameMapper": {
+      ".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "identity-obj-proxy"
+    },
     "setupFilesAfterEnv": [
       "./src/setUpTest.js"
     ]

--- a/frontEnd/src/setUpTest.js
+++ b/frontEnd/src/setUpTest.js
@@ -4,6 +4,13 @@ import 'isomorphic-fetch';
 import {setupServer} from 'msw/node';
 import {rest} from 'msw';
 
+delete window.location;
+window.location = {
+  assign: jest.fn(),
+  href: 'http://localhost',
+  origin: 'http://localhost',
+};
+
 const handlers = [
   rest.post('/login', (req, res, ctx) => {
     const {username} = req.body;
@@ -27,6 +34,9 @@ beforeAll(() => {
 });
 
 afterEach(() => {
+  window.location.assign.mockClear();
+  window.location.href = 'http://localhost';
+  window.location.origin = 'http://localhost';
   server.resetHandlers();
 });
 

--- a/frontEnd/src/utils/axios/axiosMaker.test.js
+++ b/frontEnd/src/utils/axios/axiosMaker.test.js
@@ -1,7 +1,6 @@
 import axiosMaker from './axiosMaker';
 import {rest} from 'msw';
 import server from '../../setUpTest';
-import sinon from 'sinon';
 describe('axiosMaker', () => {
   beforeEach(() => {
     server.use(
@@ -27,8 +26,8 @@ describe('axiosMaker', () => {
   });
   test('401 에러를 받을 시 localStorage에서 쿠키를 지우고 홈으로 리다이렉트를 호출한다.', async () => {
     const axiosInstance = axiosMaker();
-    window.location.assign('/fakeLocation');
     try {
+      window.location.assign('/fakeLocation');
       await axiosInstance.get('/error401');
       expect(1).toBe(2);
     } catch (e) {
@@ -42,6 +41,7 @@ describe('axiosMaker', () => {
       expect(result.status).toBe(200);
       expect(result.data.message).toBe('you WellDone');
     } catch (e) {
+      console.error(e);
       expect(1).toBe(2);
     }
   });


### PR DESCRIPTION
.png로드한 컴포넌트 테스트시 발생하는 에러는 identity-obj-proxy 모듈을 사용해서 해결했습니다.

axios maker의 경우는 setUpTest로 테스트 환경 초기화시 window.location 전체를 모킹하는 방식으로 에러가 발생하지 않도록 처리했어요