### PR TITLE
Assignee, Label 필터 기능 추가

### DIFF
--- a/backEnd/seeders/dummyData.js
+++ b/backEnd/seeders/dummyData.js
@@ -113,7 +113,6 @@ module.exports = {
         createdTime: new Date('2020-10-24T09:52:39.000Z'),
         closedTime: null,
         status: 1,
-        milestoneIdx: 1,
       },
       {
         idx: 7,
@@ -148,14 +147,6 @@ module.exports = {
       {
         userIdx: 1,
         issueIdx: 3,
-      },
-      {
-        userIdx: 1,
-        issueIdx: 5,
-      },
-      {
-        userIdx: 2,
-        issueIdx: 6,
       },
       {
         userIdx: 2,

--- a/backEnd/service/issue.js
+++ b/backEnd/service/issue.js
@@ -1,4 +1,10 @@
-const {issues, users, labels, milestones} = require('../models/index');
+const {
+  issues,
+  users,
+  labels,
+  milestones,
+  sequelize,
+} = require('../models/index');
 const {Op} = require('sequelize');
 // const getIssueList = async () => {
 //   try {
@@ -46,6 +52,7 @@ const createWhereFilterOption = (filterParams) => {
       : status === 'open'
       ? {status: true}
       : {status: false};
+  let issueLiteralCondition = '';
 
   const authorFilterObj = {
     model: users,
@@ -63,7 +70,9 @@ const createWhereFilterOption = (filterParams) => {
     attributes: ['idx', 'userId'],
   };
 
-  if (!!assignee) {
+  if (assignee === 'no') {
+    issueLiteralCondition += 'assigneeUser.idx Is NULL ';
+  } else if (!!assignee) {
     assigneeFilterObj.where = {userId: assignee};
   }
   includeFilter.push(assigneeFilterObj);
@@ -71,7 +80,12 @@ const createWhereFilterOption = (filterParams) => {
   const labelFilterObj = {
     model: labels,
   };
-  if (!!label) {
+  if (label === 'no') {
+    issueLiteralCondition +=
+      issueLiteralCondition === ''
+        ? 'labels.idx Is NULL'
+        : 'AND labels.idx Is NULL';
+  } else if (!!label) {
     labelFilterObj.where = {title: label};
   }
   includeFilter.push(labelFilterObj);
@@ -85,6 +99,7 @@ const createWhereFilterOption = (filterParams) => {
     milestoneFilterObj.where = {title: milestone};
   }
   includeFilter.push(milestoneFilterObj);
+  issueCondition.where = sequelize.literal(issueLiteralCondition);
   return {includeFilter, where: issueCondition};
 };
 


### PR DESCRIPTION
- Assignee, Label 필터 기능 추가
  - 기존에 안됬던 이유
     model을 참조한 이후 model의 내부 조건절(where)에서 특정 값 (외래키)가 null인 것을 확인 하면, 그 값 자체가 null인 것을 찾아냄.
     따라서, 값이 있는 경우를 찾아낼 수는 있지만 (not null) 값이 없는 경우(is null)을 할 수 없음
  - 해결책
    model 참조 안의 where가 아닌, findAll의 where에서 null인지 확인해주어야 함.
    하지만 assignees와 issueLabel은 모델로 존재하지 않음.
    따라서. sequelize.literal을 이용하여 assignees의 별칭인 assigneeUser와 labels를 참조하여 assigneeUser.idx와 labels.idx가 null인지 확인하면 됨.