### PR TITLE
Label Page Button disabled 구현, Filter 기본값 Is:open으로 변경

### DIFF
--- a/frontEnd/src/models/FilterModel.js
+++ b/frontEnd/src/models/FilterModel.js
@@ -82,7 +82,7 @@ const FilterModelConsumer = ({children}) => {
   const {store: issueStore, actions: issueActions} = useContext(
     modelStore.IssueList,
   );
-  const [store, dispatch] = useReducer(reducer, {});
+  const [store, dispatch] = useReducer(reducer, {Is: 'open'});
 
   const actions = {
     Author: updateAuthorAction,

--- a/frontEnd/src/models/IssueListModel.js
+++ b/frontEnd/src/models/IssueListModel.js
@@ -131,15 +131,15 @@ export function reducer(state, action) {
   }
 }
 
-const callAxios = () => {
-  return axiosMaker().get('/api/issue/list');
+const initializeCallAxios = () => {
+  return axiosMaker().post('/api/issue/list', {Is: 'open'});
 };
 
 const IssueListModelConsumer = ({children}) => {
   const [store, dispatch] = useReducer(reducer, []);
 
   useEffect(() => {
-    callAxios().then(({data}) => {
+    initializeCallAxios().then(({data}) => {
       dispatch({
         type: IssueListInitialize,
         data,

--- a/frontEnd/src/pages/issue-list-page/issue-main/issue-main-header/filter/FilterInputBox.js
+++ b/frontEnd/src/pages/issue-list-page/issue-main/issue-main-header/filter/FilterInputBox.js
@@ -79,7 +79,7 @@ const FilterInputBox = ({
         onChange={(e) => changeInputValue(e)}
         placeholder="Search All Issues"
       />
-      {inputValue !== 'Is:open' && (
+      {inputValue.replaceAll(' ', '') !== 'Is:open' && (
         <SpanWrapper onClick={clearInputValue}>
           <CancelBtnStyle>X</CancelBtnStyle>
         </SpanWrapper>

--- a/frontEnd/src/pages/issue-list-page/issue-main/issue-main-header/filter/index.js
+++ b/frontEnd/src/pages/issue-list-page/issue-main/issue-main-header/filter/index.js
@@ -61,7 +61,7 @@ const Filter = () => {
     sendRequest,
     sendRequestEvent,
   } = useInputValue({
-    initialState: '',
+    initialState: 'Is:open',
     dropdownVisibility,
     dropdownRef,
     hideDropdown,

--- a/frontEnd/src/pages/label-page/LabelInputBox.js
+++ b/frontEnd/src/pages/label-page/LabelInputBox.js
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 
 import InputWithBlueBorder from '~/*/components/input/InputWithBlueBorder';
 import randomBtnImage from '~/*/images/randomImage.png';
 
+const btnDisableColor = 'rgb(148, 211, 162)';
+const btnActiveColor = 'rgb(46, 164, 79)';
+const btnHoverColor = '#2c974b';
 const LabelInputLayout = styled.div`
   display: flex;
   flex-direction: row;
@@ -33,9 +36,12 @@ const ButtonLayout = styled.div`
   }
   .create_btn {
     color: white;
-    background-color: rgb(46, 164, 79);
+    background-color: ${(props) =>
+      props.buttonDisabled ? btnDisableColor : btnActiveColor};
+
     &:hover {
-      background-color: #2c974b;
+      ${(props) =>
+        !props.buttonDisabled && `background-color: ${btnHoverColor} `}
     }
   }
 `;
@@ -47,8 +53,9 @@ const ColorInputLayout = styled.div`
 const RandomImage = styled.img`
   cursor: pointer;
   margin: 10px 5px 0 0;
-  padding: 1px 3px;
+  padding: 1px 4px;
   height: 30px;
+  border-radius: 10px;
   background-color: ${(props) => props.color || 'transparent'};
 `;
 
@@ -84,6 +91,16 @@ const LabelInputBox = ({
   buttonName,
 }) => {
   const {idx, title, description, color} = inputs;
+  const [buttonDisabled, setButtonDisabled] = useState(title.length < 1);
+  const activeButton = ({target}) => {
+    const inputLength = target.value.length;
+    setButtonDisabled(inputLength > 0 ? false : true);
+  };
+  const onChangeHandler = (e, idx) => {
+    onChange(e, idx);
+    activeButton(e);
+  };
+
   return (
     <LabelInputLayout>
       <InputLayout>
@@ -93,7 +110,7 @@ const LabelInputBox = ({
             name="title"
             value={title}
             placeholder="Label name"
-            onChange={(e) => onChange(e, idx)}
+            onChange={(e) => onChangeHandler(e, idx)}
           />
         </TitleLabel>
         <DescLabel>
@@ -121,11 +138,15 @@ const LabelInputBox = ({
           </ColorInputLayout>
         </ColorLabel>
       </InputLayout>
-      <ButtonLayout>
+      <ButtonLayout buttonDisabled={buttonDisabled}>
         <Btn onClick={(e) => reset(e, idx)} className="cancel_btn">
           Cancel
         </Btn>
-        <Btn onClick={() => onSubmit(idx)} className="create_btn">
+        <Btn
+          disabled={buttonDisabled}
+          onClick={() => onSubmit(idx)}
+          className="create_btn"
+        >
           {buttonName}
         </Btn>
       </ButtonLayout>

--- a/frontEnd/src/utils/custom-hooks/filter-custom-hooks/useInputValue.js
+++ b/frontEnd/src/utils/custom-hooks/filter-custom-hooks/useInputValue.js
@@ -2,7 +2,7 @@ import {useState, useContext} from 'react';
 import {modelStore} from '~/*/models/store';
 import axiosMaker from '~/*/utils/axios/axiosMaker';
 
-const synchronizeModel = (filterStr, actions, dispatch) => {
+const synchronizeModel = (filterStr = '', actions, dispatch) => {
   const filterRegs = {
     Is: /(Is:open)|(Is:closed)/g,
     Author: /(Author:[\w_\-@.]+)/g,


### PR DESCRIPTION
- Label input button disabled기능 구현
   Label의 타이틀의 길이가 1보다 작을 경우, 버튼이 disabled 상태가 되도록 구현

- Label page css 수정
  Random color 버튼 border-radius 추가

- 처음 요청 시 open된 issue list를 요청하도록 변경
   IssueListModel
- Filter Model의 default state를 `{Is:"open"}`으로 변경

- Filter의 inputValue 상태의 default state를 `Is:open`으로 변경

- 필터에 `Is:open` 뒤에 공백이 붙어 나오는 경우 초기화 버튼이 렌더링 되지 않는 오류 수정
   Is:open 체크 시 공백 삭제

- 가끔 뜨는 `match is not a function` 오류 수정
  filter 기본 값이 빈 스트링이 아니어서 생기는 문제, 기본값을 ""로 설정해줌